### PR TITLE
fix: use correct error field

### DIFF
--- a/crates/misanthropy/src/error.rs
+++ b/crates/misanthropy/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
 
 impl From<ApiErrorResponse> for Error {
     fn from(error: ApiErrorResponse) -> Self {
-        match error.error_type {
+        match error.error.error_type {
             ApiErrorType::InvalidRequestError => Error::BadRequest(error.error.message),
             ApiErrorType::AuthenticationError => Error::Unauthorized(error.error.message),
             ApiErrorType::PermissionError => Error::Unauthorized(error.error.message),

--- a/crates/misanthropy/src/lib.rs
+++ b/crates/misanthropy/src/lib.rs
@@ -353,12 +353,13 @@ pub enum ApiErrorType {
 }
 
 /// The top-level error structure returned by the Anthropic API.
-/// Includes the error type and a nested ApiError with more details.
+/// Includes a nested ApiError with more details.
 #[derive(Debug, Deserialize)]
 pub struct ApiErrorResponse {
-    /// The type of error that occurred.
+    /// The type of the response; will always be "error".
+    /// See `error.error_type` for more specific information.
     #[serde(rename = "type")]
-    pub error_type: ApiErrorType,
+    pub error_type: String,
     /// Detailed information about the error.
     pub error: ApiError,
 }
@@ -368,7 +369,7 @@ pub struct ApiErrorResponse {
 pub struct ApiError {
     /// A string identifier for the error type.
     #[serde(rename = "type")]
-    pub error_type: String,
+    pub error_type: ApiErrorType,
     /// A human-readable description of the error.
     pub message: String,
 }


### PR DESCRIPTION
The `ApiErrorResponse` struct has [two `type` fields](<https://docs.anthropic.com/en/api/errors>); the outer `type` is always `error` and the inner `type` has the actual error.

The code was originally checking for the error in the outer `type`, but it should have been checking for the inner `type`. This led to every error from `ApiErrorResponse` being remapped to `Error::ApiError(...)`.

This PR fixes that by shifting the types around and using the correct field.