### PR TITLE
Fix tool choice structure

### DIFF
--- a/crates/misanthropy/src/lib.rs
+++ b/crates/misanthropy/src/lib.rs
@@ -35,7 +35,7 @@ pub use error::*;
 /// Specifies how the AI model should choose and use tools in a conversation.
 /// Can be set to automatic, any tool, or a specific tool.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[serde(rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolChoice {
     /// Let the model automatically decide whether to use tools.
     #[default]
@@ -44,7 +44,7 @@ pub enum ToolChoice {
     Any,
     /// Instruct the model to use a specific tool.
     #[serde(rename = "tool")]
-    SpecificTool(String),
+    SpecificTool { name: String },
 }
 
 /// Represents a tool that can be used by the AI model in a conversation.

--- a/crates/misanthropy/src/lib.rs
+++ b/crates/misanthropy/src/lib.rs
@@ -697,6 +697,11 @@ impl MessagesRequest {
         self
     }
 
+    pub fn with_tool_choice(mut self, tool_choice: ToolChoice) -> Self {
+        self.tool_choice = tool_choice;
+        self
+    }
+
     pub fn with_model(mut self, model: impl Into<String>) -> Self {
         self.model = model.into();
         self


### PR DESCRIPTION
The existing structure for `ToolChoice::SpecificTool` results in an API error: `tool_choice.type: Field required`, because the API is expecting `{"type": "tool", "name": string}`.

I've fixed this, while also adding `with_tool_choice` and modifying the `tools` example to specify the choice of tool with `--with-tool-choice`. I used the last one for testing - feel free to remove the corresponding commit if it doesn't fit with your vision for the example.